### PR TITLE
fix: keywords in body crash

### DIFF
--- a/src/ns_sort/core.clj
+++ b/src/ns_sort/core.clj
@@ -68,6 +68,8 @@
       (z/prewalk (fn [zloc] (z/seq? zloc))
                  (fn [zloc] (sort-val (z/next (z/down zloc)) get-sortable)))))
 
+(defn is? [sexpr] (fn [zloc] (and (= (z/tag zloc) :token) (= (z/sexpr zloc) sexpr))))
+
 (defn update-code
   "Takes a string `code` and returns an updated string with a sorted `ns` form."
   [code]
@@ -78,8 +80,8 @@
                     z/down
                     z/next
                     z/sexpr)
-          require-zloc (z/find-value zloc z/next ':require)
-          import-zloc (z/find-value zloc z/next ':import)]
+          require-zloc (z/find-next-depth-first (z/subzip zloc) (is? ':require))
+          import-zloc (z/find-next-depth-first (z/subzip zloc) (is? ':import))]
       (cond-> zloc
         require-zloc (z/subedit-> (z/find-value z/next ':require) z/up (sort-require title))
         import-zloc (z/subedit-> (z/find-value z/next ':import) z/up (sort-import title))

--- a/test/ns_sort_test.clj
+++ b/test/ns_sort_test.clj
@@ -2,49 +2,6 @@
   (:require [clojure.test :refer [deftest is]]
             [ns-sort.core :as ns-sort]))
 
-;; (deftest format-ns-test
-;;   (is (= (ns-sort/format-ns '(ns
-;;                                leiningen.ns-sort
-;;                                (:require [clojure.java.io :as io]
-;;                                          [clojure.string :as string])
-;;                                (:import (java.io File))))
-;;          "(ns leiningen.ns-sort
-;;   (:require [clojure.java.io :as io]
-;;             [clojure.string :as string])
-;;   (:import (java.io File)))")))
-
-;; (deftest sort-requires-test
-;;   (is (= (ns-sort/sort-requires 'my-server '[[schema.core :as s]
-;;                                              [compojure.api.sweet :refer [GET POST]]
-;;                                              [ring.util.http-response :refer [content-type ok]]
-;;                                              [my-server.db.api.anomalies :as db-anomalies]
-;;                                              [my-server.web.handlers.schema.common :refer [ClickhouseFieldDef]]
-;;                                              [ring.swagger.json-schema :refer [describe]]])
-
-;;          '[[my-server.db.api.anomalies :as db-anomalies]
-;;            [my-server.web.handlers.schema.common :refer [ClickhouseFieldDef]]
-;;            [compojure.api.sweet :refer [GET POST]]
-;;            [ring.swagger.json-schema :refer [describe]]
-;;            [ring.util.http-response :refer [content-type ok]]
-;;            [schema.core :as s]])))
-
-;; (deftest update-ns-test
-;;   (is (= (ns-sort/update-ns "(ns my-server
-;;   (:require [my-server.web.handlers.schema.common :refer [ClickhouseFieldDef]]
-;;             [compojure.api.sweet :refer [GET POST]]
-;;             [ring.util.http-response :refer [content-type ok]]
-;;             [ring.swagger.json-schema :refer [describe]]
-;;             [my-server.db.api.anomalies :as db-anomalies]
-;;             [schema.core :as s]))")
-
-;;          "(ns my-server
-;;   (:require [my-server.db.api.anomalies :as db-anomalies]
-;;             [my-server.web.handlers.schema.common :refer [ClickhouseFieldDef]]
-;;             [compojure.api.sweet :refer [GET POST]]
-;;             [ring.swagger.json-schema :refer [describe]]
-;;             [ring.util.http-response :refer [content-type ok]]
-;;             [schema.core :as s]))")))
-
 (deftest update-code-test
   (is (= (ns-sort/update-code (slurp "test/data/unsorted.clj-test"))
          (slurp "test/data/sorted.clj-test"))))

--- a/test/ns_sort_test.clj
+++ b/test/ns_sort_test.clj
@@ -55,4 +55,9 @@
     (is (unchanged? "(ns test-ns \"docstring\")"))
     (is (unchanged? "(ns test-ns (:require [clojure.string :as str]))"))
     (is (unchanged? "(ns test-ns (:import (java.io File)))"))
-    (is (unchanged? "(ns test-ns (:require [clojure.string :as str]) (:import (java.io File)))"))))
+    (is (unchanged?
+         "(ns test-ns (:require [clojure.string :as str]) (:import (java.io File)))"))))
+
+(deftest keywords-in-body-test
+  (ns-sort/update-code
+   "(ns test-ns (:require [clojure.string :as str])) (println :import)"))


### PR DESCRIPTION
ns-sort was crashing if it found an `:import` or `:require` keyword in the body of the code if the `ns` form didn't already have one. effectively trying to sort random body code instead of just ignoring the keyword outside of the `ns` form